### PR TITLE
ci: Add toolchain matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
   validate-pull:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.draft }}
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
     steps:
     - uses: actions/checkout@v3
     - name: Cargo Cache
@@ -32,13 +38,15 @@ jobs:
           ~/.cargo/registry/cache
           ~/.cargo/git/db
           target/
-        key: ${{ runner.os }}-cargo-cache-${{ hashFiles('Cargo.toml') }}
+        key: ${{ runner.os }}-cargo-${{ matrix.toolchain }}-${{ hashFiles('Cargo.toml') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-cache-
+          ${{ runner.os }}-cargo-${{ matrix.toolchain }}-
           ${{ runner.os }}-cargo-
           ${{ runner.os }}-
-    - run: rustup component add clippy --toolchain stable
+    - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }} && rustup component add clippy --toolchain ${{ matrix.toolchain }}
+      # The library is designed on the stable branch, meaning the check should run on a stable version.
     - name: Validate Formatting
+      if: matrix.toolchain == 'stable'
       run: cargo fmt --check --verbose
     - name: Validate Clippy
       run: cargo clippy -- -D warnings --verbose


### PR DESCRIPTION
Assuming this project may be published to `crates.io`, this adds the `toolchain` matrix strategy, to run CI against the `nightly` and `beta`, as well as `stable` toolchain branches.